### PR TITLE
Updates for ONT data

### DIFF
--- a/bin/filter.R
+++ b/bin/filter.R
@@ -484,7 +484,7 @@ FILTER_STRUC_GENE <- function(VARIANTS, GENE_SET, set = 'SHORT') {
     filter(
       Gene %in% GENE_SET
     )
-    
+      
   VARIANTS_OUT <-
     bind_rows(
       VARIANTS_OUT,
@@ -893,14 +893,14 @@ FILTER_STRUC_TYPE <- function(VARIANTS) {
       MODERATE = c('MODERATE', 'HIGH'),
       HIGH = c('HIGH')
     )[[FILTER_STRUC_VEP_MIN_IMPACT]]
-  
+
   VARIANTS_OUT <-
     VARIANTS %>% 
     filter(SVTYPE %in% FILTER_STRUC_SVTYPES) %>% 
     filter(
       IMPACT %in% FILTER_STRUC_VEP_IMPACTS |
-        Consequence %in% FILTER_STRUC_VEP_CONSEQUENCES |
-        abs(SVLEN) >= FILTER_STRUC_LARGE_LENGTH
+      str_split(Consequence, "&") %>% map_lgl(~ any(. %in% FILTER_STRUC_VEP_CONSEQUENCES)) |
+      abs(SVLEN) >= FILTER_STRUC_LARGE_LENGTH
     ) %>% 
     mutate(TYPE = SVTYPE)
   

--- a/modules/local/get_samples.nf
+++ b/modules/local/get_samples.nf
@@ -23,7 +23,9 @@ process GET_SAMPLES {
         $bams \\
         intersect_bams.tsv \\
         ${ped.size() == 0 ? 'UNSET' : ped} \\
-        intersect.ped 
+        intersect.ped
+        
+    touch warnings.txt
     """
 }
 

--- a/modules/local/samplot.nf
+++ b/modules/local/samplot.nf
@@ -21,6 +21,12 @@ process SAMPLOT {
 
     (
         while IFS=\$'\\t' read -r NAME CHROM START END TYPE; do
+
+        WINDOW_FLAG=""
+        if [[ "\$TYPE" == "INS" && "\$START" == "\$END" ]]; then
+            WINDOW_FLAG="-w 1000"
+        fi
+
         echo "samplot plot \\
             -n ${ids.join(' ')} \\
             -b ${bams.join(' ')} \\
@@ -28,7 +34,8 @@ process SAMPLOT {
             -c \$CHROM \\
             -s \$START \\
             -e \$END \\
-            -t \$TYPE"
+            -t \$TYPE \\
+            \$WINDOW_FLAG"
         done < ${sites}
     ) | xargs -n 1 -P ${task.cpus} -I {} sh -c '{}'
     """

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,10 +61,17 @@ params {
     // short variant population (gnomAD) filters
     FILTER_SHORT_POP_DOM_MAX_AF = 0.0001
     FILTER_SHORT_POP_REC_MAX_AF = 0.01
+<<<<<<< Updated upstream
     FILTER_SHORT_POP_DOM_MAX_AC = 10
     FILTER_SHORT_POP_REC_MAX_AC = 1000
     FILTER_SHORT_POP_DOM_MAX_HOM = 1
     FILTER_SHORT_POP_REC_MAX_HOM = 10
+=======
+    FILTER_SHORT_POP_DOM_MAX_AC = 20
+    FILTER_SHORT_POP_REC_MAX_AC = 1000
+    FILTER_SHORT_POP_DOM_MAX_HOM = 5
+    FILTER_SHORT_POP_REC_MAX_HOM = 20
+>>>>>>> Stashed changes
     // short variant cohort filters
     FILTER_SHORT_COH_DOM_MAX_AF = null
     FILTER_SHORT_COH_REC_MAX_AF = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -61,17 +61,10 @@ params {
     // short variant population (gnomAD) filters
     FILTER_SHORT_POP_DOM_MAX_AF = 0.0001
     FILTER_SHORT_POP_REC_MAX_AF = 0.01
-<<<<<<< Updated upstream
     FILTER_SHORT_POP_DOM_MAX_AC = 10
     FILTER_SHORT_POP_REC_MAX_AC = 1000
     FILTER_SHORT_POP_DOM_MAX_HOM = 1
     FILTER_SHORT_POP_REC_MAX_HOM = 10
-=======
-    FILTER_SHORT_POP_DOM_MAX_AC = 20
-    FILTER_SHORT_POP_REC_MAX_AC = 1000
-    FILTER_SHORT_POP_DOM_MAX_HOM = 5
-    FILTER_SHORT_POP_REC_MAX_HOM = 20
->>>>>>> Stashed changes
     // short variant cohort filters
     FILTER_SHORT_COH_DOM_MAX_AF = null
     FILTER_SHORT_COH_REC_MAX_AF = null


### PR DESCRIPTION
- samplot window flag for ONT insertions as discussed
- Fixed handling of VEP structural consequence filtering in filter.R (i.e. variants often have multiple 'Consequence' fields delimited by '&' e.g. coding_sequence_variant&5_prime_UTR_variant&intron_variant, so these were missed with the initial filtering logic)