### PR TITLE
docs: add CLAUDE.md and Filtering & Prioritisation guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repository.
+
+## Overview
+
+**nf-cavalier** is a Nextflow DSL2 pipeline for singleton and family-based candidate
+variant reporting from gene lists. It annotates, filters, visualises and reports both
+short variants (SNVs/indels) and structural variants (SVs), producing candidate-variant
+CSVs, per-family PowerPoint/PDF slide decks (with IGV/SVPV/samplot screenshots), and an
+interactive HTML variant browser. Targets GRCh38. Maintained at WEHI (Bahlo lab).
+
+## Running the pipeline
+
+Requires Nextflow ≥ 24.04 and a container runtime (Docker / Singularity / Apptainer).
+
+```bash
+# Run (expects a nextflow.config with params in the run directory)
+nextflow run nf-cavalier -resume
+
+# WEHI/Bahlolab users — preconfigured annotation cache paths
+nextflow run nf-cavalier -resume -profile bahlolab
+
+# One-time reference-data setup (downloads sources, writes a populated nextflow.config)
+nextflow run nf-cavalier/setup_anno/setup_anno.nf \
+    --resource_dir ./cavalier_refdata --config_out ./nextflow.config
+```
+
+- `--annotate_only` stops after annotation (skips the `CAVALIER` filter/report stage).
+- **Tests**: `tests/ceph_trio/` is an end-to-end 1000G CEPH trio (chr22) example. Run
+  `tests/ceph_trio/download.sh` to fetch inputs, then run with `tests/ceph_trio/test_ceph_trio.config`.
+  See [docs/test_dataset.md](docs/test_dataset.md). There is no nf-test suite or CI —
+  validation is config-based via this dataset.
+
+## Architecture / data flow
+
+[main.nf](main.nf) wires four named workflows:
+
+```
+SETUP → QC + ANNOTATE → CAVALIER   (CAVALIER skipped if params.annotate_only)
+```
+
+- **SETUP** ([workflows/setup/main.nf](workflows/setup/main.nf)) — validates params, fetches
+  & normalises gene lists to Ensembl IDs, intersects samples across VCFs/alignments/pedigree.
+- **QC** ([workflows/qc/main.nf](workflows/qc/main.nf)) — somalier (relatedness/ancestry) and
+  SCE-VCF (contamination).
+- **ANNOTATE** ([workflows/annotate/main.nf](workflows/annotate/main.nf)) — delegates to the
+  short/struc subworkflows.
+- **CAVALIER** ([workflows/cavalier/main.nf](workflows/cavalier/main.nf)) — filters variants and
+  generates CSVs, slide decks, and the HTML variant browser.
+
+Annotation subworkflows ([subworkflows/local/](subworkflows/local/)) share a scatter/gather shape:
+- `short.nf`: SCATTER → CLEAN → VCFANNO → VEP → GATHER
+- `struc.nf`: SCATTER → CLEAN_STRUC → SVAFOTATE → VEP_STRUC → GATHER
+
+## Repository layout
+
+| Path | Contents |
+|------|----------|
+| [main.nf](main.nf) | Entry point; orchestrates the four workflows |
+| [workflows/](workflows/) | `setup/`, `qc/`, `annotate/`, `cavalier/` — each a `main.nf` |
+| [subworkflows/local/](subworkflows/local/) | `short.nf`, `struc.nf` annotation paths |
+| [modules/local/](modules/local/) | One process per file (`vep.nf`, `filter.nf`, `make_slides.nf`, …) |
+| [functions/](functions/) | Shared Groovy helpers: `helpers.nf`, `channels.nf`, `validate.nf`, `vep_helpers.nf`, `vcfanno_helpers.nf` |
+| [bin/](bin/) | Scripts: R (`filter.R`, `make_slides.R`, `check_samples.R`, `init_cache.R`), Rmd (`variant_browser.Rmd`, `sce.Rmd`, `datatable.Rmd`), JS (`export_igv_png.js`), awk (`genepred_to_gff3.awk`) |
+| [setup_anno/](setup_anno/) | Standalone reference-data download/preprocess pipeline |
+| [tests/ceph_trio/](tests/) | End-to-end CEPH trio test dataset |
+| [docs/](docs/) | Human documentation (see Docs pointers) |
+| [nextflow.config](nextflow.config), [profiles.config](profiles.config), [nextflow_schema.json](nextflow_schema.json) | Configuration |
+
+## Conventions
+
+When editing or adding pipeline code, match the existing patterns:
+
+- **Process modules** live one-per-file under `modules/local/` with snake_case filenames
+  (`vep.nf`) and `UPPERCASE` process names (`VEP`). Each process opens with a comment block
+  describing its intent and carries a `tag`.
+- **Resource labels** encode CPUs/Mem/Time, e.g. `label 'C4M8T8'` (4 CPUs, 8 GB, 8 h). The
+  values are defined in [nextflow.config](nextflow.config) and scale with `task.attempt`.
+- **Container labels** are tool names, e.g. `label 'vep'`, also mapped to images in
+  [nextflow.config](nextflow.config) `withLabel:` blocks. Don't hard-code containers in modules.
+- **Optional features** are gated by `*_enabled()` helper functions (e.g. `spliceai_enabled()`,
+  `short_enabled()`) in `functions/`, included via `include { ... } from '../../functions/...'`.
+- Global `errorStrategy` retries (maxRetries 3) and `process.shell = ['/bin/bash','-euo','pipefail']`
+  are set in [nextflow.config](nextflow.config) — rely on them rather than redefining per-process.
+- Channels use `tuple val(id), path(files)` and are constructed via helpers in
+  `functions/channels.nf`.
+
+## Configuration
+
+All parameters and process resource/container labels are in [nextflow.config](nextflow.config);
+[profiles.config](profiles.config) defines the `bahlolab` profile (preconfigured cache paths);
+[nextflow_schema.json](nextflow_schema.json) describes the params for validation. Notable groups:
+
+- Primary I/O: `short_vcf`, `struc_vcf`, `alignments`, `ped`, `lists`, `outdir`.
+- `FILTER_SHORT_*` / `FILTER_STRUC_*` — frequency/inheritance/impact filter thresholds
+  (set a param to `null` to disable that filter).
+- `SLIDE_INFO_SHORT` / `SLIDE_INFO_STRUC` — map params controlling slide-deck columns.
+- Annotation sources: `vep_*`, `vcfanno_*`, `svafdb`, `ref_fasta`, `ref_gene`.
+
+## Docs pointers
+
+Defer to these for details rather than restating them:
+
+- [README.md](README.md) — purpose, quick start, pipeline diagram.
+- [docs/usage.md](docs/usage.md) — prerequisites, running, input file formats (alignments TSV, gene lists, pedigree).
+- [docs/annotations.md](docs/annotations.md) — `setup_anno` and per-source download notes.
+- [docs/parameters.md](docs/parameters.md) — every parameter with defaults.
+- [docs/output.md](docs/output.md) — output directory layout.
+- [docs/test_dataset.md](docs/test_dataset.md) — CEPH trio example.
+- [CHANGELOG.md](CHANGELOG.md) — version history (current: 26.06.0, the "v2" rewrite).

--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ nf-cavalier is developed and maintained at [WEHI](https://www.wehi.edu.au/) by:
 
 ---
 
-**Home** · [Usage](docs/usage.md) · [Annotations](docs/annotations.md) · [Parameters](docs/parameters.md) · [Output](docs/output.md) · [Test Dataset](docs/test_dataset.md)
+> **Home** &ensp;·&ensp; [Usage](docs/usage.md) &ensp;·&ensp; [Annotations](docs/annotations.md) &ensp;·&ensp; [Parameters](docs/parameters.md) &ensp;·&ensp; [Output](docs/output.md) &ensp;·&ensp; [Test Dataset](docs/test_dataset.md)

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -65,4 +65,4 @@ Generate tabix indexes locally (`tabix -p vcf <file.vcf.gz>` for each), then poi
 
 ---
 
-[Home](../README.md) · [Usage](usage.md) · **Annotations** · [Parameters](parameters.md) · [Output](output.md) · [Test Dataset](test_dataset.md)
+> [Home](../README.md) &ensp;·&ensp; [Usage](usage.md) &ensp;·&ensp; **Annotations** &ensp;·&ensp; [Parameters](parameters.md) &ensp;·&ensp; [Output](output.md) &ensp;·&ensp; [Test Dataset](test_dataset.md)

--- a/docs/output.md
+++ b/docs/output.md
@@ -56,5 +56,5 @@ These are the primary deliverables — one slide deck plus supporting results pe
 
 ---
 
-[Home](../README.md) · [Usage](usage.md) · [Annotations](annotations.md) · [Parameters](parameters.md) · **Output** · [Test Dataset](test_dataset.md)
+> [Home](../README.md) &ensp;·&ensp; [Usage](usage.md) &ensp;·&ensp; [Annotations](annotations.md) &ensp;·&ensp; [Parameters](parameters.md) &ensp;·&ensp; **Output** &ensp;·&ensp; [Test Dataset](test_dataset.md)
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -87,7 +87,7 @@ These reference and annotation paths can be populated automatically by running t
 <details>
 <summary><b>Short Variant Filters</b></summary>
 
-Variants are reported if they pass the depth/quality and population/cohort frequency filters **and** match one of the enabled variant classes (`FILTER_SHORT_LOF`, `_MISSENSE`, `_SPLICING`, `_PROMOTER`, `_OTHER`). The `TYPE='OTHER'` class is controlled by `FILTER_SHORT_VEP_MIN_IMPACT` and, optionally, the additional `FILTER_SHORT_VEP_CONSEQUENCES` list. `FILTER_SHORT_MIN_CADD_PP` and `FILTER_SHORT_MIN_SPLICEAI_PP` force-include high-scoring variants regardless of class.
+Variants are reported if they pass the depth/quality and population/cohort frequency filters **and** match one of the enabled variant classes (`FILTER_SHORT_LOF`, `_MISSENSE`, `_SPLICING`, `_PROMOTER`, `_OTHER`). The `TYPE='OTHER'` class is controlled by `FILTER_SHORT_VEP_MIN_IMPACT` and, optionally, the additional `FILTER_SHORT_VEP_CONSEQUENCES` list. `FILTER_SHORT_MIN_CADD_PP` and `FILTER_SHORT_MIN_SPLICEAI_PP` force-include high-scoring variants regardless of class. Any filter can be disabled by setting it to `null`. See [usage.md#filtering-and-prioritisation](usage.md#filtering-and-prioritisation) for an explanation of the dominant/recessive frequency regimes and how to tune them to your disease.
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -95,10 +95,10 @@ Variants are reported if they pass the depth/quality and population/cohort frequ
 | `FILTER_SHORT_MIN_GQ` | `10` | Minimum genotype quality |
 | `FILTER_SHORT_POP_DOM_MAX_AF` | `0.0001` | Max population (gnomAD) AF for dominant variants |
 | `FILTER_SHORT_POP_REC_MAX_AF` | `0.01` | Max population (gnomAD) AF for recessive variants |
-| `FILTER_SHORT_POP_DOM_MAX_AC` | `10` | Max population (gnomAD) AC for dominant variants |
-| `FILTER_SHORT_POP_REC_MAX_AC` | `1000` | Max population (gnomAD) AC for recessive variants |
-| `FILTER_SHORT_POP_DOM_MAX_HOM` | `1` | Max population (gnomAD) homozygotes for dominant variants |
-| `FILTER_SHORT_POP_REC_MAX_HOM` | `10` | Max population (gnomAD) homozygotes for recessive variants |
+| `FILTER_SHORT_POP_DOM_MAX_AC` | `null` | Max population (gnomAD) AC for dominant variants (`null` = disabled) |
+| `FILTER_SHORT_POP_REC_MAX_AC` | `null` | Max population (gnomAD) AC for recessive variants (`null` = disabled) |
+| `FILTER_SHORT_POP_DOM_MAX_HOM` | `null` | Max population (gnomAD) homozygotes for dominant variants (`null` = disabled) |
+| `FILTER_SHORT_POP_REC_MAX_HOM` | `null` | Max population (gnomAD) homozygotes for recessive variants (`null` = disabled) |
 | `FILTER_SHORT_COH_DOM_MAX_AF` | `null` | Max cohort AF for dominant variants |
 | `FILTER_SHORT_COH_REC_MAX_AF` | `null` | Max cohort AF for recessive variants |
 | `FILTER_SHORT_COH_DOM_MAX_AC` | `null` | Max cohort AC for dominant variants |
@@ -136,14 +136,16 @@ Variants are reported if they pass the depth/quality and population/cohort frequ
 <details>
 <summary><b>Structural Variant Filters</b></summary>
 
+Structural variants follow the same dominant/recessive × population/cohort frequency model as short variants — see [usage.md#filtering-and-prioritisation](usage.md#filtering-and-prioritisation). Any filter can be disabled by setting it to `null`.
+
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `FILTER_STRUC_POP_DOM_MAX_AF` | `0.0001` | Max population AF for dominant SVs |
 | `FILTER_STRUC_POP_REC_MAX_AF` | `0.01` | Max population AF for recessive SVs |
 | `FILTER_STRUC_POP_DOM_MAX_HOM` | `null` | Max population homozygotes for dominant SVs |
 | `FILTER_STRUC_POP_REC_MAX_HOM` | `null` | Max population homozygotes for recessive SVs |
-| `FILTER_STRUC_COH_DOM_MAX_AF` | `0.01` | Max cohort AF for dominant SVs |
-| `FILTER_STRUC_COH_REC_MAX_AF` | `0.01` | Max cohort AF for recessive SVs |
+| `FILTER_STRUC_COH_DOM_MAX_AF` | `null` | Max cohort AF for dominant SVs (`null` = disabled) |
+| `FILTER_STRUC_COH_REC_MAX_AF` | `null` | Max cohort AF for recessive SVs (`null` = disabled) |
 | `FILTER_STRUC_COH_DOM_MAX_AC` | `null` | Max cohort AC for dominant SVs |
 | `FILTER_STRUC_COH_REC_MAX_AC` | `null` | Max cohort AC for recessive SVs |
 | `FILTER_STRUC_SVTYPES` | `'DEL,DUP,INS,INV'` | SV types to retain (BND is currently excluded upstream due to a VEP issue) |
@@ -167,5 +169,5 @@ Variants are reported if they pass the depth/quality and population/cohort frequ
 
 ---
 
-[Home](../README.md) · [Usage](usage.md) · [Annotations](annotations.md) · **Parameters** · [Output](output.md) · [Test Dataset](test_dataset.md)
+> [Home](../README.md) &ensp;·&ensp; [Usage](usage.md) &ensp;·&ensp; [Annotations](annotations.md) &ensp;·&ensp; **Parameters** &ensp;·&ensp; [Output](output.md) &ensp;·&ensp; [Test Dataset](test_dataset.md)
 

--- a/docs/test_dataset.md
+++ b/docs/test_dataset.md
@@ -85,4 +85,4 @@ Under `output/`:
 
 ---
 
-[Home](../README.md) · [Usage](usage.md) · [Annotations](annotations.md) · [Parameters](parameters.md) · [Output](output.md) · **Test Dataset**
+> [Home](../README.md) &ensp;·&ensp; [Usage](usage.md) &ensp;·&ensp; [Annotations](annotations.md) &ensp;·&ensp; [Parameters](parameters.md) &ensp;·&ensp; [Output](output.md) &ensp;·&ensp; **Test Dataset**

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -166,6 +166,79 @@ params {
 }
 ```
 
----
+## Filtering and Prioritisation
 
-[Home](../README.md) · **Usage** · [Annotations](annotations.md) · [Parameters](parameters.md) · [Output](output.md) · [Test Dataset](test_dataset.md)
+This section explains *how* and *why* variants are filtered, so you can tune the thresholds to your disease of interest. The full parameter list with defaults is in [parameters.md](parameters.md#short-variant-filters); the explanation below covers the model behind the frequency filters in particular.
+
+### How variants are filtered
+
+For each family (or singleton), a candidate variant must pass **all** of the following to be reported:
+
+1. **Variant class** — for short variants, an enabled class (`LOF`, `MISSENSE`, `SPLICING`, `PROMOTER`, `OTHER`) determined from VEP impact/consequence and, where relevant, CADD / SpliceAI / PromoterAI scores. For structural variants, an allowed SV type (`FILTER_STRUC_SVTYPES`) and VEP impact/consequence (`FILTER_STRUC_VEP_MIN_IMPACT`, `FILTER_STRUC_VEP_CONSEQUENCES`); SVs longer than `FILTER_STRUC_LARGE_LENGTH` are reported automatically.
+2. **Gene list** — it must fall in a gene from one of your `lists`.
+3. **Inheritance and frequency** — it must segregate with the phenotype **and** be rare enough under the frequency thresholds for its inheritance mode (see below).
+4. **Genotype quality** (short variants only) — each contributing genotype must meet `FILTER_SHORT_MIN_DP` (depth, default `5`) and `FILTER_SHORT_MIN_GQ` (genotype quality, default `10`). Structural-variant calls have no depth/quality filter.
+
+Variant class and gene-list membership decide *whether a variant is the kind we care about*; the frequency filters decide *whether it is rare enough to be plausibly causal*. The frequency step is where disease-specific tuning matters most.
+
+### Dominant vs recessive frequency regimes
+
+nf-cavalier does **not** apply a single frequency cut-off. Each variant is first assigned an observed inheritance mode from how it segregates with affected/unaffected status, and that mode selects which frequency thresholds apply:
+
+- **dominant** — affected individuals are heterozygous (HET) and unaffected individuals are reference (REF).
+- **recessive** — affected individuals are homozygous (HOM) and no unaffected individual is HOM.
+
+For a **singleton** (one affected sample, no pedigree) this reduces to zygosity: a **heterozygous** call is evaluated under the **dominant** thresholds, and a **homozygous** call under the **recessive** thresholds.
+
+The two regimes exist because the expected population frequency of a causal allele differs by inheritance mode — a dominant disease allele should be very rare in the population, whereas a recessive allele can be carried (heterozygously) at appreciable frequency. Accordingly the defaults are much stricter for dominant variants:
+
+- `FILTER_SHORT_POP_DOM_MAX_AF = 0.0001` (dominant)
+- `FILTER_SHORT_POP_REC_MAX_AF = 0.01` (recessive)
+
+A heterozygous variant that is too common for the dominant threshold but still within the recessive threshold is **not discarded** — it is reclassified as a `compound` candidate and retained for compound-heterozygous analysis (it is reported only if a second qualifying hit is found in the same gene).
+
+### Population vs cohort frequency
+
+Two independent frequency sources are checked, each with its own dominant/recessive thresholds:
+
+- **Population (`POP`)** — gnomAD allele frequencies. `POP` AF uses the higher of gnomAD AF and the 95% filtering allele frequency (FAF95); `POP` also exposes allele count (`AC`) and homozygote count (`HOM`, gnomAD `nhomalt`). Use these to exclude variants that are too common in the general population.
+- **Cohort (`COH`)** — frequencies computed from *your own* joint-called VCF (`AF`, `AC`). Use these to suppress variants that are common **within your cohort** — typically recurrent sequencing artefacts or shared common variants — which population databases may not flag.
+
+Setting any threshold to `null` disables that particular check (it never removes a variant).
+
+### Key frequency parameters and defaults
+
+Short-variant frequency filters (structural-variant equivalents use the `FILTER_STRUC_*` prefix):
+
+| Parameter | Default | Applies to | Effect |
+|-----------|---------|------------|--------|
+| `FILTER_SHORT_POP_DOM_MAX_AF` | `0.0001` | dominant (HET) | Max gnomAD AF/FAF95 |
+| `FILTER_SHORT_POP_REC_MAX_AF` | `0.01` | recessive (HOM) | Max gnomAD AF/FAF95 |
+| `FILTER_SHORT_POP_DOM_MAX_AC` | `null` (off) | dominant | Max gnomAD allele count |
+| `FILTER_SHORT_POP_REC_MAX_AC` | `null` (off) | recessive | Max gnomAD allele count |
+| `FILTER_SHORT_POP_DOM_MAX_HOM` | `null` (off) | dominant | Max gnomAD homozygote count |
+| `FILTER_SHORT_POP_REC_MAX_HOM` | `null` (off) | recessive | Max gnomAD homozygote count |
+| `FILTER_SHORT_COH_DOM_MAX_AF` | `null` (off) | dominant | Max cohort AF |
+| `FILTER_SHORT_COH_REC_MAX_AF` | `null` (off) | recessive | Max cohort AF |
+| `FILTER_SHORT_COH_DOM_MAX_AC` | `null` (off) | dominant | Max cohort allele count |
+| `FILTER_SHORT_COH_REC_MAX_AC` | `null` (off) | recessive | Max cohort allele count |
+
+By default only the population **AF** filters are active; the AC, HOM and cohort filters are off (`null`) and can be enabled as needed. Structural variants follow the same `DOM`/`REC` × `POP`/`COH` pattern (`FILTER_STRUC_POP_DOM_MAX_AF = 0.0001`, `FILTER_STRUC_POP_REC_MAX_AF = 0.01`; population AC is not used for SVs).
+
+### Choosing thresholds for your disease
+
+The population AF thresholds effectively cap the **maximum credible frequency of a disease allele** — as a rule of thumb it should not exceed the disease prevalence, adjusted for penetrance and inheritance mode. Adjust the defaults when your disease does not fit them:
+
+- **Rare, highly penetrant dominant disorder** — tighten `POP_DOM_MAX_AF` below the `0.0001` default to reduce false positives; setting `POP_DOM_MAX_HOM = 0` (no population homozygotes) is a strong additional filter.
+- **Recessive disorder with a common carrier allele** (e.g. founder variants) — raise `POP_REC_MAX_AF` above `0.01` to admit the real allele, optionally bounding by `POP_REC_MAX_HOM` so alleles seen homozygous in healthy individuals are still removed.
+- **Recurrent cohort artefacts** — enable the `COH_*` filters to drop variants common within your own cohort even when gnomAD does not flag them.
+
+### Variants retained regardless of frequency
+
+- **ClinVar pathogenic** — variants whose ClinVar `CLNSIG` matches `FILTER_SHORT_CLINVAR_KEEP_PAT` (default matches "pathogenic") are retained even if they exceed the frequency thresholds, provided they still segregate with the phenotype. `FILTER_SHORT_CLINVAR_DISC_PAT` (default "benign") discards matching benign classifications.
+- **CADD / SpliceAI / PromoterAI** scores influence only the **variant class** assignment (`FILTER_SHORT_MIN_CADD_PP`, `FILTER_SHORT_MIN_SPLICEAI_PP`, `FILTER_SHORT_MAX_PROMOTERAI`); they do **not** exempt a variant from the frequency or segregation filters.
+
+See [parameters.md](parameters.md#short-variant-filters) for the complete list of filter parameters, including the variant-class flags and ClinVar settings.
+
+---
+> [Home](../README.md) &ensp;·&ensp; **Usage** &ensp;·&ensp; [Annotations](annotations.md) &ensp;·&ensp; [Parameters](parameters.md) &ensp;·&ensp; [Output](output.md) &ensp;·&ensp; [Test Dataset](test_dataset.md)

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,12 +64,12 @@ params {
     FILTER_SHORT_MIN_DP = 5
     FILTER_SHORT_MIN_GQ = 10
     // short variant population (gnomAD) filters
-    FILTER_SHORT_POP_DOM_MAX_AF = 0.0001
-    FILTER_SHORT_POP_REC_MAX_AF = 0.01
-    FILTER_SHORT_POP_DOM_MAX_AC = 10
-    FILTER_SHORT_POP_REC_MAX_AC = 1000
-    FILTER_SHORT_POP_DOM_MAX_HOM = 1
-    FILTER_SHORT_POP_REC_MAX_HOM = 10
+    FILTER_SHORT_POP_DOM_MAX_AF  = 0.0001
+    FILTER_SHORT_POP_REC_MAX_AF  = 0.01
+    FILTER_SHORT_POP_DOM_MAX_AC  = null
+    FILTER_SHORT_POP_REC_MAX_AC  = null
+    FILTER_SHORT_POP_DOM_MAX_HOM = null
+    FILTER_SHORT_POP_REC_MAX_HOM = null
     // short variant cohort filters
     FILTER_SHORT_COH_DOM_MAX_AF = null
     FILTER_SHORT_COH_REC_MAX_AF = null
@@ -134,13 +134,13 @@ params {
     ref_gene = null
 
     // structural variant population (gnomAD) filters
-    FILTER_STRUC_POP_DOM_MAX_AF = 0.0001
-    FILTER_STRUC_POP_REC_MAX_AF = 0.01
+    FILTER_STRUC_POP_DOM_MAX_AF  = 0.0001
+    FILTER_STRUC_POP_REC_MAX_AF  = 0.01
     FILTER_STRUC_POP_DOM_MAX_HOM = null
     FILTER_STRUC_POP_REC_MAX_HOM = null
-    // strucutural  variant cohort filters
-    FILTER_STRUC_COH_DOM_MAX_AF = 0.01
-    FILTER_STRUC_COH_REC_MAX_AF = 0.01
+    // strucutural variant cohort filters
+    FILTER_STRUC_COH_DOM_MAX_AF = null
+    FILTER_STRUC_COH_REC_MAX_AF = null
     FILTER_STRUC_COH_DOM_MAX_AC = null
     FILTER_STRUC_COH_REC_MAX_AC = null
     FILTER_STRUC_SVTYPES          = 'DEL,DUP,INS,INV' // N.B. BND currently excluded upstream due to VEP issue


### PR DESCRIPTION
- add CLAUDE.md project guide for Claude Code sessions
- add "Filtering and Prioritisation" section to docs/usage.md explaining the dominant/recessive frequency regimes and how to tune them
- sync docs/parameters.md filter defaults to nextflow.config and cross-link
- disable POP AC/HOM and SV cohort-AF filters by default (null) in nextflow.config
- style doc footer navigation bars (blockquote, en-space separators)